### PR TITLE
Fix Broken THANKS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ See [LICENSE](https://github.com/mistic/static-fs/blob/master/LICENSE).
 
 ## Thanks
 
-Our thanks can be read at [THANKS](https://github.com/mistic/blob/master/THANKS.md).
+Our thanks can be read at [THANKS](./THANKS.md).
   
 [ci-build-status-image]: https://github.com/mistic/static-fs/workflows/CI.CD/badge.svg?branch=master 
 [ci-build-status-url]: https://github.com/mistic/static-fs/actions?query=workflow%3ACI.CD+branch%3Amaster


### PR DESCRIPTION
The current THANKS link is broken (it's missing the repo name).

This PR sets it as a relative path, but I can change it to absolute one if required